### PR TITLE
Error for woo 3+ and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ If you like this plugin consider [donating](http://jakeii.github.com/woocommerce
 ##Requirements
 (Same as Woocommerce)
 * Wordpress 3.3+
+* Woocommerce 3+
 * PHP 5.2.4+
 * MySQl 5.0+
 

--- a/gateway.php
+++ b/gateway.php
@@ -330,7 +330,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
         function thankyou_page($order_id) {
           global $woocommerce;
           
-          $order = new wc_get_order( $order_id );
+          $order = wc_get_order( $order_id );
           
           // Remove cart
           $woocommerce->cart->empty_cart();
@@ -485,10 +485,10 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
           $order                      = new wc_get_order( $order_id );
           $pesapal_args['total']      = $order->get_total();
           $pesapal_args['reference']  = $order_id;
-          $pesapal_args['first_name'] = $order->billing_first_name;
-          $pesapal_args['last_name']  = $order->billing_last_name;
-          $pesapal_args['email']      = $order->billing_email;
-          $pesapal_args['phone']      = $order->billing_phone;
+          $pesapal_args['first_name'] = $order->billing_first_name();
+          $pesapal_args['last_name']  = $order->billing_last_name();
+          $pesapal_args['email']      = $order->billing_email();
+          $pesapal_args['phone']      = $order->billing_phone();
           
           $i = 0;
           foreach($order->get_items() as $item){

--- a/gateway.php
+++ b/gateway.php
@@ -328,7 +328,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
         function thankyou_page($order_id) {
           global $woocommerce;
           
-          $order = new WC_Order( $order_id );
+          $order = new wc_get_order( $order_id );
           
           // Remove cart
           $woocommerce->cart->empty_cart();
@@ -348,7 +348,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
         function process_payment( $order_id ) {
           global $woocommerce;
         
-          $order = new WC_Order( $order_id );
+          $order = new wc_get_order( $order_id );
         
           // Redirect to payment page
           return array(
@@ -386,7 +386,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
           if(isset($_GET['pesapal_transaction_tracking_id'])){
             
             $order_id = $_GET['order'];
-            $order    = new WC_Order( $order_id );
+            $order    = new wc_get_order( $order_id );
             $pesapalMerchantReference = $_GET['pesapal_merchant_reference'];
             $pesapalTrackingId        = $_GET['pesapal_transaction_tracking_id'];
             
@@ -430,7 +430,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 
             foreach($checks as $check){
             
-              $order = new WC_Order( $check->order_id );
+              $order = new wc_get_order( $check->order_id );
             
               $status = $this->status_request($check->tracking_id, $check->order_id);
             
@@ -458,7 +458,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
          * @author Jake Lee Kennedy
          **/
         function create_url($order_id){
-          $order            = new WC_Order( $order_id );
+          $order            = new wc_get_order( $order_id );
           $order_xml        = $this->pesapal_xml($order_id);
           $callback_url     = add_query_arg('key', $order->order_key, add_query_arg('order', $order_id, get_permalink(woocommerce_get_page_id('pay'))));
           
@@ -480,7 +480,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
          **/
         function pesapal_xml($order_id) {
           
-          $order                      = new WC_Order( $order_id );
+          $order                      = new wc_get_order( $order_id );
           $pesapal_args['total']      = $order->get_total();
           $pesapal_args['reference']  = $order_id;
           $pesapal_args['first_name'] = $order->billing_first_name;
@@ -671,7 +671,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
           //$status	        = $this->checkTransactionStatus($pesapalMerchantReference);
           //$status 	        = $this->checkTransactionStatus($pesapalMerchantReference,$pesapalTrackingId);
           $transactionDetails	= $this->getTransactionDetails($pesapalMerchantReference,$pesapalTrackingId);
-          $order                = new WC_Order($pesapalMerchantReference);
+          $order                = new wc_get_order($pesapalMerchantReference);
            
           // We are here so lets check status and do actions
 	        switch ( $transactionDetails['status'] ) {
@@ -707,7 +707,7 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 	            break;
 	        }
 
-          $order      = new WC_Order($pesapalMerchantReference);
+          $order      = new wc_get_order($pesapalMerchantReference);
           $newstatus  = $order->status;
 
 	

--- a/gateway.php
+++ b/gateway.php
@@ -8,6 +8,8 @@ Author: Jake Lee Kennedy
 Author URI: http://bodhi.io
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
+WC requires at least: 3.0.0
+WC tested up to: 3.2.0
 
 Copyright 2012  Jake Lee Kennedy  (email : jake@bodhi.io)
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Jakeii
 Donate link: http://jakeii.github.com/woocommerce-pesapal/
 Tags: pesapal, woocommerce, ecommerce, gateway, payment
 Requires at least: 3.3
-Tested up to: 4.1.1
+Tested up to: 4.9
 Stable tag: 1.0.2
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
Since Woocommerce mega major Update 3.0+ things have changed quite a lot:

WC_Order properties can't be access directly as before and will throw some errors.
New WC_Order and C_Abstract_Order getters and setters methods are now needed. There is some New classes for Order items: WC_Order_Item class.
WC_Order_Item_Product class.
So also the Order items properties will not be accessible as before in a foreach loop and you will have to use this specific getter and setter methods instead.

Using some WC_Order and WC_Abstract_Order methods (example):

// Get an instance of the WC_Order object (same as before)
$order = wc_get_order( $order_id );